### PR TITLE
Many fixes and console clean up

### DIFF
--- a/scenes/bullets-demo.js
+++ b/scenes/bullets-demo.js
@@ -38,18 +38,17 @@ export default class BulletsDemoScene extends Phaser.Scene {
     create() {
         this.audio_manager.on_create();
         this.audio_manager.setVolume(AudioType.SFX, 1);
-        console.log('BulletsDemoScene');
         this.gameObjects = [];
         const map = this.make.tilemap({ key: 'map' });
 
         const tileset = map.addTilesetImage('Dungeon_Tileset', 'tiles');
 
-        const belowFloor = map.createLayer('Ground', tileset, 0, 0);
+        // const belowFloor = map.createLayer('Ground', tileset, 0, 0);
         const belowLayer = map.createLayer('Floor', tileset, 0, 0);
         const worldLayer = map.createLayer('Walls', tileset, 0, 0);
-        const decals = map.createLayer('Decals', tileset, 0, 0);
+        // const decals = map.createLayer('Decals', tileset, 0, 0);
         const aboveLayer = map.createLayer('Upper', tileset, 0, 0);
-        const aboveUpper = map.createLayer('Leaves', tileset, 0, 0);
+        // const aboveUpper = map.createLayer('Leaves', tileset, 0, 0);
         this.tileSize = 32;
 
         worldLayer.setCollisionBetween(1, 500);
@@ -76,14 +75,18 @@ export default class BulletsDemoScene extends Phaser.Scene {
         this.lastTick = getTime();
 
         // test bullet reactions with realtime added objects
-        setTimeout(() => {
-            const newDog = this.add.sprite(600, 200, 'dog01');
-            this.physics.add.existing(newDog);
-            newDog.setScale(0.5);
-            /** @type {Phaser.Physics.Arcade.Body}*/ (newDog.body).setSize(180, 130);
-            /** @type {Phaser.Physics.Arcade.Body}*/ (newDog.body).setOffset(50, 48);
-            this.gameObjects.push(newDog);
-        }, 3000);
+        this.time.addEvent({
+            delay: 3000,
+            callback: () => {
+                const newDog = this.add.sprite(600, 200, 'dog01');
+                this.physics.add.existing(newDog);
+                newDog.setScale(0.5);
+                /** @type {Phaser.Physics.Arcade.Body}*/ (newDog.body).setSize(180, 130);
+                /** @type {Phaser.Physics.Arcade.Body}*/ (newDog.body).setOffset(50, 48);
+                this.gameObjects.push(newDog);
+            },
+            callbackScope: this,
+        });
     }
 
     update() {

--- a/scenes/loader-test-scene.js
+++ b/scenes/loader-test-scene.js
@@ -17,7 +17,6 @@ class LoaderTestScene extends Phaser.Scene {
     }
 
     create() {
-        console.log(LoaderTestScene);
         this.gameObjects = [];
         const map = this.make.tilemap({key: 'map'});
 

--- a/scenes/mainMenu-scene.js
+++ b/scenes/mainMenu-scene.js
@@ -10,7 +10,6 @@ export default class MainMenuScene extends Phaser.Scene {
 
 
     preload(){
-        console.log('hello');
         this.load.image('playButtonDefault', 'sprites/pack/UI/Free Upgrade Screen/Artboard 3_1.png');
         this.load.image('playButtonHover', 'sprites/pack/UI/Free Upgrade Screen/Artboard 3 copy.png');
         this.load.image('backgroundImage', 'sprites/pack/UI/Free Upgrade Screen/Artboard 2.png');

--- a/scenes/map-gen2-demo.js
+++ b/scenes/map-gen2-demo.js
@@ -12,6 +12,7 @@ const height = 35;
 export default class MapGen2DemoScene extends Phaser.Scene {
     /** @type {MapGenManager2 | null} */ genMap;
     /** @type {Phaser.GameObjects.Sprite[]} */ gameObjects;
+    /** @type {Phaser.Cameras.Controls.FixedKeyControl} */ controls;
 
     constructor() {
         super({ key: 'MapGen2DemoScene' });
@@ -22,7 +23,7 @@ export default class MapGen2DemoScene extends Phaser.Scene {
         this.load.image('tiles', 'tileset/Dungeon_Tileset.png');
         
         FlagManager.preload(this);
-        this.genmap = new MapGenManager2(width, height)
+        this.genMap = new MapGenManager2(width, height)
     }
 
     create() {
@@ -36,7 +37,9 @@ export default class MapGen2DemoScene extends Phaser.Scene {
         //Add flag spawn
 
         this.input.on('pointerdown', (pointer) => {
-            this.spawn(pointer);
+            const x = this.cameras.main.centerX + (pointer.x - this.cameras.main.centerX) / this.cameras.main.zoomX + this.cameras.main.scrollX;
+            const y = this.cameras.main.centerY + (pointer.y - this.cameras.main.centerY) / this.cameras.main.zoomY + this.cameras.main.scrollY;
+            this.spawn({x, y});
         });
 
         const tileset = map.addTilesetImage('Dungeon_Tileset', 'tiles');

--- a/scenes/steering-scene.js
+++ b/scenes/steering-scene.js
@@ -26,16 +26,15 @@ export class SteeringScene extends Phaser.Scene {
 
     create() {
         const map = this.make.tilemap({ key: 'map' });
-        console.log(map);
 
         const tileset = map.addTilesetImage('Dungeon_Tileset', 'tiles');
 
-        const belowFloor = map.createLayer('Ground', tileset, 0, 0);
+        // const belowFloor = map.createLayer('Ground', tileset, 0, 0);
         const belowLayer = map.createLayer('Floor', tileset, 0, 0);
         const worldLayer = map.createLayer('Walls', tileset, 0, 0);
-        const decals = map.createLayer('Decals', tileset, 0, 0);
+        // const decals = map.createLayer('Decals', tileset, 0, 0);
         const aboveLayer = map.createLayer('Upper', tileset, 0, 0);
-        const aboveUpper = map.createLayer('Leaves', tileset, 0, 0);
+        // const aboveUpper = map.createLayer('Leaves', tileset, 0, 0);
         this.tileSize = 32;
 
         worldLayer.setCollisionBetween(1, 500);

--- a/scenes/vfx-demo.js
+++ b/scenes/vfx-demo.js
@@ -22,7 +22,7 @@ export default class VfxDemoScene extends Phaser.Scene {
 
     preload() {
         this.load.image('tiles', 'tileset/Dungeon_Tileset.png');
-        this.load.tilemapTiledJSON('map', 'dungeon_room.json');
+        this.load.tilemapTiledJSON('map2', 'dungeon_room2.json');
 
         this.load.image('dog01', 'sprites/pack/Characters/Dogs/Dog01/Idle/Idle_00.png');
         this.load.audio('gun_cocking', 'sfx/gun-cocking.mp3');
@@ -47,7 +47,8 @@ export default class VfxDemoScene extends Phaser.Scene {
         ParticlesSystem.init();
 
         this.gameObjects = [];
-        const map = this.make.tilemap({ key: 'map' });
+        this.unitGameObjects = [];
+        const map = this.make.tilemap({ key: 'map2' });
 
         const tileset = map.addTilesetImage('Dungeon_Tileset', 'tiles');
 
@@ -119,9 +120,11 @@ export default class VfxDemoScene extends Phaser.Scene {
             this.penguin.reloadGun();
         });
 
-        setInterval(() => {
-            ParticlesSystem.create('Exposion', 200, 500, 0, 0.3)
-        }, 3000)
+        this.time.addEvent({
+            delay: 3000,
+            callback: () => ParticlesSystem.create('Exposion', 200, 500, 0, 0.3),
+            loop: true
+        });
     }
 
     update() {

--- a/src/objects/Flag.js
+++ b/src/objects/Flag.js
@@ -5,7 +5,6 @@ class Flag
 	 */
     constructor(scene, sprite = "flag1", location = [400, 300]) {
         this.scene = scene;
-		console.log(scene);
         this.sprite = this.scene.add.sprite(location[0], location[1], sprite);
 	}
 }

--- a/src/systems/CameraMain.js
+++ b/src/systems/CameraMain.js
@@ -10,7 +10,7 @@ export class CameraMain {
     static cameraScene;
 
     /**
-     * @param {Phaser.Scene} scene
+     * @param {Phaser.Scene & { controls: Phaser.Cameras.Controls.FixedKeyControl }} scene
      */
     constructor(scene, maxwidtht, maxheight) {
         const cursors = scene.input.keyboard.createCursorKeys();


### PR DESCRIPTION
### `CameraMain.js`

- Уточнён тип в JSDoc

### `Flag.js`

- Убран вывод в консоль.

### `mainMenu-scene.js`

- Убран вывод в консоль.

### `loader-test-scene.js`

- Убран вывод в консоль.

### steering-scene.js

- Убран вывод в консоль.
- Закомментированы несуществующие слои в тайловой карте. Предупреждений в консоли больше нет.

### `bullets-demo.js`

- Убран вывод в консоль.
- Сценонезависимый `setTimeout` заменён на `this.time.addEvent`. Теперь при переключении между сценами не будет происходить ошибок.
- Закомментированы несуществующие слои в тайловой карте. Предупреждений в консоли больше нет.

### `vfx-demo.js`

- Так как в коде используется слой `aboveUpper`, то теперь эта сцена переделана на карту `dungeon_room2.json` с ключом `map2`.
- Частицы заменены со сценонезависимого `setInterval` на `this.time.addEvent`.
- `this.unitGameObjects` не инициализировался, из-за этого сцена загружалась + падал фазер. Инициализация добавлена, сцена работает.

### `map-gen2-demo.js`

- Исправлена опечатка `this.genmap` -> `this.genMap`. Сцена теперь работает.
- Добавлен `controls` в описание класса.
- Спавн флагов работает нормально для разной позиции/приближения камеры.
